### PR TITLE
Add new blog post about internal researcher platform

### DIFF
--- a/app/blog/posts/the-internal-researcher-platform-revolutionizing-research-operations.mdx
+++ b/app/blog/posts/the-internal-researcher-platform-revolutionizing-research-operations.mdx
@@ -1,0 +1,179 @@
+---
+title: 'The Internal Researcher Platform: Revolutionizing Research Operations Through Self‑Service Infrastructure'
+publishedAt: '2025-09-27'
+summary: 'Applying Internal Developer Platform principles to research operations — how self‑service infrastructure can transform research velocity, reproducibility, and collaboration while maintaining compliance and quality standards.'
+---
+
+The software development world has been transformed by Internal Developer Platforms (IDPs), which provide developers with self-service access to infrastructure, tools, and processes needed to build, deploy, and manage applications efficiently. These platforms have dramatically improved developer productivity by abstracting away complex infrastructure management while maintaining governance and security standards.
+
+What if we applied this same transformative approach to research operations? Enter the Internal Researcher Platform (IRP) – a paradigm shift that promises to revolutionize how research teams conduct, manage, and scale their work across organizations.
+
+## What is an Internal Researcher Platform?
+
+An Internal Researcher Platform is a self-service interface between researchers and the underlying computational infrastructure, data resources, analytical tools, and compliance frameworks required to conduct, reproduce, and scale research activities. Just as IDPs enable developers to focus on writing code rather than managing infrastructure, IRPs enable researchers to focus on generating insights rather than wrestling with computational environments, data access, and tool configuration.
+
+## The Research Productivity Crisis
+
+Modern research organizations face remarkably similar challenges to what software development teams encountered before IDPs became mainstream:
+
+**Fragmented Tool Ecosystems:** Researchers waste countless hours setting up environments, installing dependencies, and configuring analysis pipelines
+
+**Data Access Friction:** Locating, accessing, and preparing research datasets often takes longer than the actual analysis
+
+**Reproducibility Challenges:** Research projects become difficult to reproduce due to environment inconsistencies and undocumented dependencies
+
+**Compliance Bottlenecks:** Navigating institutional policies, data governance, and ethical review processes creates significant delays
+
+**Resource Management Overhead:** Researchers spend substantial time managing computational resources rather than conducting research
+
+## Core Components of an Internal Researcher Platform
+
+### 1. Self-Service Research Environments
+
+The IRP provides researchers with on-demand access to pre-configured computational environments tailored to different research domains:
+
+**Template-Based Workspaces:** Pre-built environments for common research patterns (statistical analysis, machine learning, literature review, data visualization)
+
+**Scalable Computing:** Automatic provisioning of computational resources based on project needs
+
+**Environment Versioning:** Immutable research environments that ensure reproducibility across time
+
+### 2. Unified Data Catalog and Access Layer
+
+A centralized system for discovering, accessing, and managing research data:
+
+**Data Discovery:** Searchable catalog of available datasets with metadata, lineage, and access permissions
+
+**Automated Data Pipelines:** Self-service data ingestion and preprocessing workflows
+
+**Privacy-Preserving Access:** Built-in anonymization, differential privacy, and access controls
+
+### 3. Integrated Analytical Toolchain
+
+Seamless access to research tools and libraries:
+
+**Multi-Language Support:** Environments supporting R, Python, Julia, MATLAB, and domain-specific tools
+
+**Package Management:** Automated dependency resolution and version management
+
+**Collaborative Notebooks:** Shared computational notebooks with real-time collaboration features
+
+### 4. Automated Compliance and Ethics Workflow
+
+Built-in governance that doesn't impede research velocity:
+
+**Ethics Review Integration:** Streamlined IRB submission and approval tracking
+
+**Data Governance:** Automatic application of data handling policies based on data classification
+
+**Audit Trails:** Comprehensive logging of data access and analytical processes
+
+### 5. Publication and Sharing Infrastructure
+
+Tools for disseminating research outputs:
+
+**Reproducible Reports:** Automated generation of research reports with embedded code and data
+
+**Collaboration Spaces:** Shared workspaces for cross-functional research teams
+
+**Output Management:** Versioned storage and sharing of research artifacts
+
+### 6. Resource Optimization and Cost Management
+
+Intelligent resource allocation and usage monitoring:
+
+**Auto-Scaling Computing:** Dynamic allocation of computational resources based on workload
+
+**Cost Transparency:** Real-time visibility into resource consumption and associated costs
+
+**Usage Analytics:** Insights into research workflow patterns and optimization opportunities
+
+## Benefits of the Internal Researcher Platform Approach
+
+### For Individual Researchers
+
+**Faster Time-to-Insight:** Eliminate setup friction and focus on research questions
+
+**Enhanced Reproducibility:** Consistent environments ensure reliable research outcomes
+
+**Simplified Collaboration:** Easy sharing of code, data, and computational environments
+
+**Reduced Technical Debt:** No more maintaining personal tool collections and configurations
+
+### For Research Organizations
+
+**Improved Research Velocity:** Standardized workflows accelerate project completion
+
+**Better Resource Utilization:** Shared infrastructure reduces duplicate tool procurement
+
+**Enhanced Compliance:** Built-in governance ensures consistent policy adherence
+
+**Knowledge Preservation:** Systematic capture of research methodologies and insights
+
+### For Research Management
+
+**Visibility and Oversight:** Real-time dashboards showing research progress and resource usage
+
+**Quality Assurance:** Standardized environments reduce methodology variability
+
+**Risk Mitigation:** Built-in security and compliance controls reduce institutional risk
+
+**Strategic Planning:** Usage analytics inform resource allocation and tool investment decisions
+
+## Implementation Patterns
+
+### The Federated Model
+
+Large research institutions can implement IRPs using a federated approach where individual departments maintain their specialized tools while sharing common infrastructure:
+
+**Shared Core Services:** Common data catalog, authentication, and computational resources
+
+**Department-Specific Extensions:** Specialized tools and workflows for different research domains
+
+**Cross-Department Collaboration:** Unified interfaces for interdisciplinary projects
+
+### The Platform Team Approach
+
+Organizations can establish dedicated Platform Teams responsible for building and maintaining the IRP:
+
+**Product Mindset:** Treating researchers as customers with specific needs and requirements
+
+**Continuous Improvement:** Regular feedback collection and platform evolution
+
+**Community Building:** Foster adoption through training and success stories
+
+## Real-World Applications
+
+### Academic Research Institutions
+
+Universities can deploy IRPs to support diverse research activities across multiple disciplines, from social sciences requiring survey data analysis to computational biology requiring high-performance computing resources.
+
+### Corporate Research Labs
+
+Technology companies can use IRPs to accelerate product research, market analysis, and experimental design while maintaining intellectual property protection and regulatory compliance.
+
+### Government Research Agencies
+
+Federal research organizations can leverage IRPs to standardize research methodologies, improve inter-agency collaboration, and ensure compliance with data handling regulations.
+
+## The Future of Research Operations
+
+The Internal Researcher Platform represents a fundamental shift in how we think about research infrastructure. By applying the lessons learned from Internal Developer Platforms, we can create environments where researchers spend their time generating insights rather than managing tools.
+
+Just as IDPs have become mainstream in software development organizations, we anticipate that IRPs will become the standard approach for research-intensive organizations seeking to maximize their analytical capabilities while maintaining quality and compliance standards.
+
+## Getting Started
+
+Organizations interested in building Internal Researcher Platforms should start by:
+
+**Conducting Research Workflow Audits:** Understanding how researchers currently work and identifying pain points
+
+**Building Cross-Functional Teams:** Including researchers, IT professionals, and compliance experts
+
+**Starting with Pilot Projects:** Implementing IRPs for specific research domains before expanding organization-wide
+
+**Establishing Feedback Loops:** Creating mechanisms for continuous improvement based on researcher needs
+
+The Internal Researcher Platform approach promises to transform research operations in the same way that Internal Developer Platforms have revolutionized software development. Organizations that embrace this paradigm will gain significant competitive advantages in research velocity, quality, and innovation capacity.
+
+The research landscape is evolving rapidly, and organizations that provide their researchers with modern, self-service platforms will be best positioned to drive breakthrough discoveries and maintain competitive advantages in an increasingly data-driven world.


### PR DESCRIPTION
Add a new blog post titled "The Internal Researcher Platform: Revolutionizing Research Operations Through Self‑Service Infrastructure" to expand blog content.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7c6653f-f5f1-47d2-9a01-32117d57e41a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7c6653f-f5f1-47d2-9a01-32117d57e41a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

