### PR TITLE
Spread blog dates over last year and a half

### DIFF
--- a/app/blog/posts/ai-and-platform-engineering-in-healthcare-and-biotechnology-the-next-frontier-of-medical-innovation.mdx
+++ b/app/blog/posts/ai-and-platform-engineering-in-healthcare-and-biotechnology-the-next-frontier-of-medical-innovation.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'AI and Platform Engineering in Healthcare and Biotechnology: The Next Frontier of Medical Innovation'
-publishedAt: '2025-09-28'
+publishedAt: '2025-09-15'
 summary: 'Artificial Intelligence is fundamentally reshaping healthcare delivery and biotechnology research, with platform engineering at the epicenter of this transformation. This comprehensive guide explores how AI intersects with healthcare and biotech platform engineering, exposing real challenges and opportunities while providing practical frameworks for platform teams navigating this critical transformation.'
 ---
 

--- a/app/blog/posts/ai-templates-accelerating-development.mdx
+++ b/app/blog/posts/ai-templates-accelerating-development.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'The Power of Templates: Accelerating AI‑Driven Development'
-publishedAt: '2025-09-25'
+publishedAt: '2025-08-22'
 summary: 'Why AI templates matter: faster start, more control, and better AI outputs through clear, in‑repo context.'
 ---
 

--- a/app/blog/posts/beyond-studies-say-so-why-i-choose-to-avoid-msg.mdx
+++ b/app/blog/posts/beyond-studies-say-so-why-i-choose-to-avoid-msg.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Beyond "Studies Say So": Why I Choose to Avoid MSG'
-publishedAt: '2025-09-26'
+publishedAt: '2025-07-18'
 summary: 'A personal reflection on how we make decisions about food additives, the limitations of "studies say so" arguments, and why I choose evolutionary wisdom over modern convenience.'
 ---
 

--- a/app/blog/posts/blueprint-for-an-ai-driven-health-utopia.mdx
+++ b/app/blog/posts/blueprint-for-an-ai-driven-health-utopia.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Blueprint for an AI‑Driven Health Utopia'
-publishedAt: '2025-01-27'
+publishedAt: '2025-06-12'
 summary: 'Envisioning a future where AI transforms healthcare from reactive treatment to proactive prevention, creating a world of personalized, accessible, and equitable health outcomes.'
 ---
 

--- a/app/blog/posts/can-we-please-get-rid-of-paradigms.mdx
+++ b/app/blog/posts/can-we-please-get-rid-of-paradigms.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Can We Please Get Rid of Paradigms?'
-publishedAt: '2025-09-25'
+publishedAt: '2025-05-08'
 summary: 'Why Naval Ravikant's principles, AI, and the rise of polymaths point toward a post‑paradigmatic future where first‑principles thinking transcends rigid frameworks.'
 ---
 

--- a/app/blog/posts/devops-for-healthcare-and-research.mdx
+++ b/app/blog/posts/devops-for-healthcare-and-research.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DevOps for Healthcare and Research: Building CI/CD Pipelines for Human Flourishing"
-publishedAt: "2025-04-15"
+publishedAt: "2025-04-03"
 summary: "What if we applied DevOps principles to healthcare and research? Exploring how continuous integration, deployment, and monitoring could revolutionize how we develop treatments and deliver care."
 ---
 

--- a/app/blog/posts/from-mba-to-maa-structuring-an-agent-native-company.mdx
+++ b/app/blog/posts/from-mba-to-maa-structuring-an-agent-native-company.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'From MBA to MAA: Structuring an Agent‑Native Company'
-publishedAt: '2025-09-25'
+publishedAt: '2025-03-14'
 summary: 'Introducing the MAA — Master of Agent Administration — a practical playbook to design orgs, systems, and governance for autonomous and AI agents.'
 ---
 

--- a/app/blog/posts/genie-3-and-the-simulation-hypothesis.mdx
+++ b/app/blog/posts/genie-3-and-the-simulation-hypothesis.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Genie 3 and the Simulation Hypothesis'
-publishedAt: '2025-08-06'
+publishedAt: '2024-12-18'
 summary: 'DeepMind’s Genie 3 pushes real‑time, interactive world models. Here’s why it reopens the simulation hypothesis conversation, and what it means for synthetic realities.'
 ---
 

--- a/app/blog/posts/how-people-use-chatgpt-part-1-methodology-and-scope.mdx
+++ b/app/blog/posts/how-people-use-chatgpt-part-1-methodology-and-scope.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'How People Use ChatGPT: Part 1 — Methodology and Scope'
-publishedAt: '2025-09-23'
+publishedAt: '2024-11-05'
 summary: 'A deep dive into the NBER study that tracked ChatGPT adoption from launch to 10% global penetration. What the methodology reveals about AI adoption research and why this study matters.'
 ---
 

--- a/app/blog/posts/i-want-my-multi-organ-agents-in-production.mdx
+++ b/app/blog/posts/i-want-my-multi-organ-agents-in-production.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'I Want My Multi‑Organ Agents in Production'
-publishedAt: '2025-01-28'
+publishedAt: '2024-10-22'
 summary: 'The future of healthcare AI isn't single-organ models—it's coordinated, intelligent agents that simulate entire biological systems. Here's why we need to move beyond research and into production today.'
 ---
 

--- a/app/blog/posts/if-ai-only-wrote-assembly-rethinking-abstraction-from-scratch.mdx
+++ b/app/blog/posts/if-ai-only-wrote-assembly-rethinking-abstraction-from-scratch.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'If AI Only Wrote Assembly: Rethinking Abstraction From Scratch'
-publishedAt: '2025-03-02'
+publishedAt: '2024-09-14'
 summary: 'If we restarted software from zero with AI at the metal, which abstractions would survive, and what should we change today?'
 ---
 

--- a/app/blog/posts/introducing-gait-an-ai-first-git.mdx
+++ b/app/blog/posts/introducing-gait-an-ai-first-git.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Introducing GAIT: An AI‑First Git'
-publishedAt: '2025-01-17'
+publishedAt: '2024-08-07'
 summary: 'GAIT is a fork of Git exploring what version control would look like if AI had been in the room on day one.'
 ---
 

--- a/app/blog/posts/introducing-pupai-an-ai-first-husky.mdx
+++ b/app/blog/posts/introducing-pupai-an-ai-first-husky.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Introducing PupAI: An AI‑First Fork of Husky'
-publishedAt: '2025-05-14'
+publishedAt: '2024-07-19'
 summary: 'PupAI is a playful, AI‑first fork of Husky that turns Git hooks into intelligent workflows: parallel agent sessions, policy‑aware automation, and hook‑level AI actions you can verify and trust.'
 ---
 

--- a/app/blog/posts/reviewing-the-chatgpt-usage-study-my-analysis-plan.mdx
+++ b/app/blog/posts/reviewing-the-chatgpt-usage-study-my-analysis-plan.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Reviewing the ChatGPT Usage Study: My Analysis Plan'
-publishedAt: '2025-09-16'
+publishedAt: '2024-06-25'
 summary: 'How I plan to dissect the most comprehensive study of AI adoption to date. A structured approach to analyzing 2.5 years of ChatGPT usage data across five focused posts.'
 ---
 

--- a/app/blog/posts/the-importance-of-wandering-in-the-ai-era.mdx
+++ b/app/blog/posts/the-importance-of-wandering-in-the-ai-era.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'The Importance of Wandering in the AI Era'
-publishedAt: '2025-02-15'
+publishedAt: '2024-05-30'
 summary: 'In an age of rapid AI advancement, philosophical wandering and questioning reality from the outside becomes essential for staying grounded in truth and understanding what is real.'
 ---
 

--- a/app/blog/posts/the-internal-biotech-platform-accelerating-drug-discovery.mdx
+++ b/app/blog/posts/the-internal-biotech-platform-accelerating-drug-discovery.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'The Internal Biotech Platform: Accelerating Drug Discovery Through Self‑Service Laboratory Infrastructure'
-publishedAt: '2025-09-27'
+publishedAt: '2024-04-18'
 summary: 'How applying the Internal Developer Platform model to biotechnology can transform laboratory operations, accelerate research timelines, and bring life‑changing therapeutics to market faster.'
 ---
 

--- a/app/blog/posts/the-internal-hospital-platform-transforming-healthcare-delivery.mdx
+++ b/app/blog/posts/the-internal-hospital-platform-transforming-healthcare-delivery.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'The Internal Hospital Platform: Transforming Healthcare Delivery Through Self‑Service Clinical Infrastructure'
-publishedAt: '2025-09-27'
+publishedAt: '2024-03-22'
 summary: 'How Internal Developer Platform principles can revolutionize healthcare operations by providing self‑service access to clinical infrastructure, reducing provider burnout, and dramatically improving patient care quality.'
 ---
 

--- a/app/blog/posts/the-internal-researcher-platform-revolutionizing-research-operations.mdx
+++ b/app/blog/posts/the-internal-researcher-platform-revolutionizing-research-operations.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'The Internal Researcher Platform: Revolutionizing Research Operations Through Self‑Service Infrastructure'
-publishedAt: '2025-09-27'
+publishedAt: '2024-03-05'
 summary: 'Applying Internal Developer Platform principles to research operations — how self‑service infrastructure can transform research velocity, reproducibility, and collaboration while maintaining compliance and quality standards.'
 ---
 

--- a/app/blog/posts/thinking-about-bug-bounty-for-health.mdx
+++ b/app/blog/posts/thinking-about-bug-bounty-for-health.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Thinking About Bug Bounty for Health"
-publishedAt: "2024-12-19"
+publishedAt: "2025-01-10"
 summary: "What if we applied the bug bounty model to health and medical research? Exploring how distributed intelligence could accelerate medical breakthroughs."
 ---
 

--- a/app/blog/posts/why-non-technical-customers-dont-get-excited-about-new-ai-models.mdx
+++ b/app/blog/posts/why-non-technical-customers-dont-get-excited-about-new-ai-models.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Why Non‑Technical Customers Don't Get as Excited About New AI Models as You Think'
-publishedAt: '2025-09-25'
+publishedAt: '2025-02-28'
 summary: 'The gap between technical improvements and user adoption: why communication habits and relationship patterns matter more than raw intelligence in AI tools.'
 ---
 

--- a/app/blog/posts/why-platform-engineering-is-the-ultimate-approach-for-healthcare-and-biotechnology-transformation.mdx
+++ b/app/blog/posts/why-platform-engineering-is-the-ultimate-approach-for-healthcare-and-biotechnology-transformation.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Why Platform Engineering is the Ultimate Approach for Healthcare and Biotechnology Transformation'
-publishedAt: '2025-09-27'
+publishedAt: '2025-09-28'
 summary: 'Healthcare and biotechnology organizations face the same fragmented workflow crisis that software development solved with platform engineering. By applying proven platform principles to clinical operations and biotech research, we can dramatically improve patient outcomes and accelerate scientific discovery.'
 ---
 

--- a/app/blog/posts/why-we-must-focus-on-solving-health.mdx
+++ b/app/blog/posts/why-we-must-focus-on-solving-health.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Why We Must Focus on Solving Health'
-publishedAt: '2025-01-27'
+publishedAt: '2025-09-01'
 summary: 'A personal reflection on mortality, consciousness, and why solving health is the most important problem humanity faces—and the key to unlocking our full potential.'
 ---
 


### PR DESCRIPTION
Update blog post `publishedAt` dates to spread them across the last year and a half.

Previously, all blog posts had dates clustered around September 2025. This change distributes them from March 2024 to September 2025 to create a more realistic and varied publishing timeline.

---
<a href="https://cursor.com/background-agent?bcId=bc-396691ba-aebd-4990-99d7-4c977964403f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-396691ba-aebd-4990-99d7-4c977964403f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

