### PR TITLE
Remove deploy nav link and fix author name in blog schema

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -77,7 +77,7 @@ export default function Blog({ params }) {
             url: `${baseUrl}/blog/${post.slug}`,
             author: {
               '@type': 'Person',
-              name: 'My Portfolio',
+              name: 'yamz8',
             },
           }),
         }}

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -7,9 +7,6 @@ const navItems = {
   '/blog': {
     name: 'blog',
   },
-  'https://vercel.com/templates/next.js/portfolio-starter-kit': {
-    name: 'deploy',
-  },
 }
 
 export function Navbar() {


### PR DESCRIPTION
## Summary

- Remove the "deploy" link from the nav (was pointing to the Vercel template)
- Fix author name in blog post JSON-LD schema from "My Portfolio" to "yamz8"

---
_Generated by [Claude Code](https://claude.ai/code/session_019d7jz7k7WZdeHPis8kPqLi)_